### PR TITLE
fixed nullpointer exception due to getParentFile

### DIFF
--- a/src/main/java/io/vertx/codegen/cli/Main.java
+++ b/src/main/java/io/vertx/codegen/cli/Main.java
@@ -182,7 +182,7 @@ public class Main {
       URLClassLoader classLoader = (URLClassLoader) CodeGenProcessor.class.getClassLoader();
       Method addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
       addURL.setAccessible(true);
-      addURL.invoke(classLoader, codegenFile.getParentFile().toURI().toURL());
+      addURL.invoke(classLoader, codegenFile.getAbsoluteFile().getParentFile().toURI().toURL());
     }
 
     // Builder options


### PR DESCRIPTION
When new File object is constructed , if it has relative path without any perfix , like when running codegen command directly in same directory , getParentFile() method retrurns null. But when we first get getAbsoluteFile() , It returns same file with absolute path. Then getting  getParentFile() seems working fiine. http://docs.oracle.com/javase/7/docs/api/java/io/File.html#getParentFile()
